### PR TITLE
Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Message.Data field which contains a copy of the ReceiveMessageEvent.Data value
 - Add Message.AuthorID field which contains a copy of the ReceiveMessageEvent.AuthorID value 
 - Add Auth.Grant(…) and Auth.CheckPermission(…) functions to allow implementing user permissions
+- Add Brain.Close() function to let the brain implement the Memory interface
+- Add Brain.SetMemory(…) function to give more control over a joe.Brain
 
 ## [v0.6.0] - 2019-03-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-Nothing so far
+- Add ReceiveMessageEvent.Data field to allow using the underlying message type of the adapters
+- Add ReceiveMessageEvent.AuthorID field to identify the author of the message
+- Add Message.Data field which contains a copy of the ReceiveMessageEvent.Data value
+- Add Message.AuthorID field which contains a copy of the ReceiveMessageEvent.AuthorID value 
 
 ## [v0.6.0] - 2019-03-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ReceiveMessageEvent.AuthorID field to identify the author of the message
 - Add Message.Data field which contains a copy of the ReceiveMessageEvent.Data value
 - Add Message.AuthorID field which contains a copy of the ReceiveMessageEvent.AuthorID value 
+- Add Brain.Grant(…) Brain.CheckPermission(…) functions to allow implementing user permissions
 
 ## [v0.6.0] - 2019-03-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Auth.Grant(…) and Auth.CheckPermission(…) functions to allow implementing user permissions
 - Add Brain.Close() function to let the brain implement the Memory interface
 - Add Brain.SetMemory(…) function to give more control over a joe.Brain
+- Fix joetest.Bot.Start(…) function to return only when actually _all_ initialization is done
 
 ## [v0.6.0] - 2019-03-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ReceiveMessageEvent.AuthorID field to identify the author of the message
 - Add Message.Data field which contains a copy of the ReceiveMessageEvent.Data value
 - Add Message.AuthorID field which contains a copy of the ReceiveMessageEvent.AuthorID value 
-- Add Brain.Grant(…) Brain.CheckPermission(…) functions to allow implementing user permissions
+- Add Auth.Grant(…) and Auth.CheckPermission(…) functions to allow implementing user permissions
 
 ## [v0.6.0] - 2019-03-30
 ### Added

--- a/auth.go
+++ b/auth.go
@@ -11,11 +11,13 @@ import (
 // ErrNotAllowed is returned if the user is not allowed access to a specific scope.
 const ErrNotAllowed = Error("not allowed")
 
+// Auth implements logic to add user authorization checks to your bot.
 type Auth struct {
 	logger *zap.Logger
 	memory Memory
 }
 
+// NewAuth creates a new Auth instance.
 func NewAuth(logger *zap.Logger, memory Memory) *Auth {
 	return &Auth{
 		logger: logger,
@@ -23,8 +25,8 @@ func NewAuth(logger *zap.Logger, memory Memory) *Auth {
 	}
 }
 
-// CheckPermissions checks if a user has permissions to access a resource under
-// a given scope. If the user is not permitted access this function returns
+// CheckPermission checks if a user has permissions to access a resource under a
+// given scope. If the user is not permitted access this function returns
 // ErrNotAllowed.
 //
 // Scopes are interpreted in a hierarchical way where scope A can be contained

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,66 @@
+package joe
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// ErrNotAllowed is returned if the user is not allowed access to a specific scope.
+const ErrNotAllowed = Error("not allowed")
+
+type auth struct {
+	mu          sync.RWMutex
+	permissions map[string][]string // maps user IDs to a list of granted scopes
+}
+
+func newAuth() *auth {
+	return &auth{permissions: map[string][]string{}}
+}
+
+// CheckPermissions checks if a user has permissions to access a resource under
+// a given scope. If the user is not permitted access this function returns
+// ErrNotAllowed.
+//
+// Scopes are interpreted in a hierarchical way where scope A can be contained
+// in scope B if B is a prefix to A. For example, you can check if a user is
+// allowed to read or write from the "Example" API by checking the
+// "api.example.read" or "api.example.write" scope. When you grant the scope to
+// a user you can now either decide only to grant the very specific
+// "api.example.read" scope which means the user will not have write permissions
+// or you can allow people write-only access via "api.example.write".
+// Alternatively you can also grant any access to the Example API via "api.example"
+// which includes both the read and write scope beneath it. If you choose to you
+// could also allow even more general access to everything in the api via the
+// "api" scope. The empty scope "" cannot be granted and will thus always return
+// an error in the permission check.
+func (a *auth) CheckPermission(scope, userID string) error {
+	a.mu.RLock()
+	permissions := a.permissions[userID]
+	a.mu.RUnlock()
+
+	for _, p := range permissions {
+		if strings.HasPrefix(scope, p) {
+			return nil
+		}
+	}
+
+	return ErrNotAllowed
+}
+
+// Grant adds a new permission scope to the given user. When a scope was granted
+// to a specific user it can be checked later via CheckPermission(…). The empty
+// scope cannot be granted and trying to do so will result in an error. If you
+// want to grant access to all scopes you should prefix them with a common scope
+// such as "root." or "api.".
+func (a *auth) Grant(scope, userID string) error {
+	if scope == "" {
+		return errors.New("scope cannot be empty")
+	}
+
+	a.mu.Lock()
+	a.permissions[userID] = append(a.permissions[userID], scope)
+	a.mu.Unlock()
+	return nil
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,47 @@
+package joe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuth(t *testing.T) {
+	auth := newAuth()
+	userID := "fgrosse"
+
+	// Initially the user should have no permissions whatsoever
+	err := auth.CheckPermission("test.foo", userID)
+	require.Equal(t, ErrNotAllowed, err)
+
+	// Granting the empty scope is likely an error and thus should result in an error
+	err = auth.Grant("", userID)
+	require.EqualError(t, err, "scope cannot be empty")
+	err = auth.CheckPermission("", userID)
+	require.Equal(t, ErrNotAllowed, err)
+
+	// Grant the test.foo scope
+	err = auth.Grant("test.foo", userID)
+	require.NoError(t, err)
+
+	// The user has exactly the test.foo scope and should be granted access.
+	err = auth.CheckPermission("test.foo", userID)
+	require.NoError(t, err)
+
+	// test.foo.bar is contained in the test.foo scope and the user should be granted access.
+	err = auth.CheckPermission("test.foo.bar", userID)
+	require.NoError(t, err)
+
+	// test is not contained in the test.foo scope so this should be denied.
+	err = auth.CheckPermission("test", userID)
+	require.Equal(t, ErrNotAllowed, err)
+
+	// foo is also not contained in the test.foo scope so this should be denied.
+	err = auth.CheckPermission("foo", userID)
+	require.Equal(t, ErrNotAllowed, err)
+
+	// Even though test.foo and test.bar share a common prefix this scope is not entirely
+	// contained in the granted scope so this should be denied.
+	err = auth.CheckPermission("test.bar", userID)
+	require.Equal(t, ErrNotAllowed, err)
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -4,10 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestAuth(t *testing.T) {
-	auth := newAuth()
+	logger := zaptest.NewLogger(t)
+	mem := newInMemory()
+	auth := NewAuth(logger, mem)
 	userID := "fgrosse"
 
 	// Initially the user should have no permissions whatsoever

--- a/bot.go
+++ b/bot.go
@@ -100,7 +100,7 @@ func New(name string, modules ...Module) *Bot {
 		ctx:     conf.Context,
 		Logger:  conf.logger,
 		Adapter: conf.adapter,
-		Auth:    NewAuth(conf.logger, brain.memory),
+		Auth:    NewAuth(conf.logger, brain),
 		Brain:   brain,
 		initErr: multierr.Combine(conf.errs...),
 	}
@@ -206,7 +206,7 @@ func (b *Bot) Run() error {
 		b.Logger.Info("Error while closing adapter", zap.Error(err))
 	}
 
-	err = b.Brain.memory.Close()
+	err = b.Brain.Close() // TODO: should this happen in Brain.Shutdown(…) ?
 	if err != nil {
 		b.Logger.Info("Error while closing memory", zap.Error(err))
 	}

--- a/bot.go
+++ b/bot.go
@@ -265,11 +265,13 @@ func (b *Bot) RespondRegex(expr string, fun func(Message) error) {
 		}
 
 		return fun(Message{
-			Context: ctx,
-			Text:    evt.Text,
-			Channel: evt.Channel,
-			Matches: matches[1:],
-			adapter: b.Adapter,
+			Context:  ctx,
+			Text:     evt.Text,
+			AuthorID: evt.AuthorID,
+			Data:     evt.Data,
+			Channel:  evt.Channel,
+			Matches:  matches[1:],
+			adapter:  b.Adapter,
 		})
 	})
 }

--- a/bot.go
+++ b/bot.go
@@ -26,6 +26,7 @@ type Bot struct {
 	Name    string
 	Adapter Adapter
 	Brain   *Brain
+	Auth    *Auth
 	Logger  *zap.Logger
 
 	ctx     context.Context
@@ -99,6 +100,7 @@ func New(name string, modules ...Module) *Bot {
 		ctx:     conf.Context,
 		Logger:  conf.logger,
 		Adapter: conf.adapter,
+		Auth:    NewAuth(conf.logger, brain.memory),
 		Brain:   brain,
 		initErr: multierr.Combine(conf.errs...),
 	}

--- a/bot_test.go
+++ b/bot_test.go
@@ -120,7 +120,7 @@ func TestBot_Respond_AuthorID(t *testing.T) {
 	b.Start()
 	defer b.Stop()
 
-	// Test if extra data passed via the ReceiveMessageEvent is copied to the Message
+	// Test if author ID passed via the ReceiveMessageEvent is copied to the Message
 	b.Brain.Emit(joe.ReceiveMessageEvent{
 		Text:     "Test message",
 		AuthorID: "Friedrich",

--- a/bot_test.go
+++ b/bot_test.go
@@ -17,6 +17,16 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
+func TestBot_New(t *testing.T) {
+	b := joe.New("test")
+	require.NotNil(t, b)
+	require.Equal(t, "test", b.Name)
+	require.NotNil(t, b.Auth)
+	require.NotNil(t, b.Logger)
+	require.NotNil(t, b.Brain)
+	require.NotNil(t, b.Adapter)
+}
+
 func TestBot_Run(t *testing.T) {
 	b := joetest.NewBot(t)
 
@@ -257,6 +267,35 @@ func TestBot_RespondRegex_Invalid(t *testing.T) {
 	err := b.Run()
 	require.Error(t, err)
 	require.Regexp(t, `invalid event handlers: .+\.go:\d+: error parsing regexp: missing closing \]`, err.Error())
+}
+
+func TestBot_Auth(t *testing.T) {
+	b := joetest.NewBot(t)
+	b.Respond("auth test", func(msg joe.Message) error {
+		err := b.Auth.CheckPermission("test.foo", msg.AuthorID)
+		if err != nil {
+			msg.Respond("I'm sorry Dave, I'm afraid I can't do that")
+			return nil
+		}
+
+		msg.Respond("OK")
+		return nil
+	})
+
+	b.Start()
+	assert.Equal(t, "test > ", b.ReadOutput())
+
+	userID := "42"
+	b.EmitSync(joe.ReceiveMessageEvent{Text: "auth test", AuthorID: userID})
+	assert.Equal(t, "I'm sorry Dave, I'm afraid I can't do that\n", b.ReadOutput())
+
+	err := b.Auth.Grant("test", userID)
+	require.NoError(t, err)
+
+	b.EmitSync(joe.ReceiveMessageEvent{Text: "auth test", AuthorID: userID})
+	assert.Equal(t, "OK\n", b.ReadOutput())
+
+	b.Stop()
 }
 
 func TestBot_CloseAdapter(t *testing.T) {

--- a/bot_test.go
+++ b/bot_test.go
@@ -274,12 +274,10 @@ func TestBot_Auth(t *testing.T) {
 	b.Respond("auth test", func(msg joe.Message) error {
 		err := b.Auth.CheckPermission("test.foo", msg.AuthorID)
 		if err != nil {
-			msg.Respond("I'm sorry Dave, I'm afraid I can't do that")
-			return nil
+			return msg.RespondE("I'm sorry Dave, I'm afraid I can't do that")
 		}
 
-		msg.Respond("OK")
-		return nil
+		return msg.RespondE("OK")
 	})
 
 	b.Start()

--- a/brain.go
+++ b/brain.go
@@ -80,6 +80,13 @@ func NewBrain(logger *zap.Logger) *Brain {
 	return b
 }
 
+// SetMemory assigns a different Memory to the Brain.
+func (b *Brain) SetMemory(m Memory) {
+	b.mu.Lock()
+	b.memory = m
+	b.mu.Unlock()
+}
+
 func (b *Brain) isHandlingEvents() bool {
 	return atomic.LoadInt32(&b.handlingEvents) == 1
 }
@@ -431,6 +438,14 @@ func (b *Brain) Memories() (map[string]string, error) {
 	b.mu.RUnlock()
 
 	return data, err
+}
+
+// Close shuts down the Memory of the brain.
+func (b *Brain) Close() error {
+	b.mu.Lock()
+	err := b.memory.Close()
+	b.mu.Unlock()
+	return err
 }
 
 func checkHandlerParams(handlerFunc reflect.Type) (evtType reflect.Type, withContext bool, err error) {

--- a/brain.go
+++ b/brain.go
@@ -21,7 +21,6 @@ import (
 // or deleted on the brain.
 type Brain struct {
 	logger *zap.Logger
-	*auth
 
 	mu     sync.RWMutex // mu protects concurrent access to the Memory as well as registering new handlers
 	memory Memory
@@ -68,7 +67,6 @@ func NewBrain(logger *zap.Logger) *Brain {
 
 	b := &Brain{
 		logger:         logger,
-		auth:           newAuth(),
 		memory:         newInMemory(),
 		eventsInput:    make(chan Event),
 		eventsLoop:     make(chan Event),

--- a/brain.go
+++ b/brain.go
@@ -21,6 +21,7 @@ import (
 // or deleted on the brain.
 type Brain struct {
 	logger *zap.Logger
+	*auth
 
 	mu     sync.RWMutex // mu protects concurrent access to the Memory as well as registering new handlers
 	memory Memory
@@ -67,6 +68,7 @@ func NewBrain(logger *zap.Logger) *Brain {
 
 	b := &Brain{
 		logger:         logger,
+		auth:           newAuth(),
 		memory:         newInMemory(),
 		eventsInput:    make(chan Event),
 		eventsLoop:     make(chan Event),

--- a/error.go
+++ b/error.go
@@ -1,0 +1,10 @@
+package joe
+
+// Error is the error type used by Joe. This allows joe errors to be defined as
+// constants following https://dave.cheney.net/2016/04/07/constant-errors.
+type Error string
+
+// Error implements the "error" interface of the standard library.
+func (err Error) Error() string {
+	return string(err)
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,13 @@
+package joe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestError(t *testing.T) {
+	var err error
+	err = Error("test")
+	assert.Equal(t, "test", err.Error())
+}

--- a/error_test.go
+++ b/error_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestError(t *testing.T) {
-	var err error
-	err = Error("test")
+	var err error = Error("test") // compiler check to make sure we are actually implementing the "error" interface
 	assert.Equal(t, "test", err.Error())
 }

--- a/events.go
+++ b/events.go
@@ -11,8 +11,15 @@ type ShutdownEvent struct{}
 // The ReceiveMessageEvent is typically emitted by an Adapter when the Bot sees
 // a new message from the chat.
 type ReceiveMessageEvent struct {
-	Text    string
-	Channel string
+	Text     string // The message text.
+	AuthorID string // A string identifying the author of the message on the adapter.
+	Channel  string // The channel over which the message was received.
+
+	// A message may optionally also contain additional information that was
+	// received by the Adapter (e.g. with the slack adapter this may be the
+	// *slack.MessageEvent. Each Adapter implementation should document if and
+	// what information is available here, if any at all.
+	Data interface{}
 }
 
 // The UserTypingEvent is emitted by the Adapter and indicates that the Bot

--- a/joetest/bot.go
+++ b/joetest/bot.go
@@ -117,3 +117,15 @@ func (b *Bot) Stop() {
 		b.T.Errorf("Bot.Run() returned an error: %v", err)
 	}
 }
+
+// ReadOutput consumes all data from b.Output and returns it as a string so you
+// can easily make assertions on it.
+func (b *Bot) ReadOutput() string {
+	out, err := ioutil.ReadAll(b.Output)
+	if err != nil {
+		b.T.Errorf("failed to read all output of bot: %v", err)
+		return ""
+	}
+
+	return string(out)
+}

--- a/joetest/bot.go
+++ b/joetest/bot.go
@@ -85,9 +85,17 @@ func (b *Bot) EmitSync(event interface{}) {
 // the InitEvent.
 func (b *Bot) Start() {
 	started := make(chan bool)
-	b.Brain.RegisterHandler(func(evt joe.InitEvent) {
+
+	type InitTestEvent struct{}
+	b.Brain.RegisterHandler(func(evt InitTestEvent) {
 		started <- true
 	})
+
+	// When this event is handled we know the bot has completed its startup and
+	// is ready to process events. The joe.InitEvent isn't really an option here
+	// because it only marks that the bot is starting but we do not know when
+	// all other init handlers are done (e.g. for the CLI adapter).
+	b.Brain.Emit(InitTestEvent{})
 
 	go func() {
 		// The error will be available by calling Bot.Stop()

--- a/memory_test.go
+++ b/memory_test.go
@@ -1,3 +1,40 @@
 package joe
 
+import "github.com/stretchr/testify/mock"
+
 // The inMemory type is fully tested in brain_test.go via TestBrain_Memory(…).
+
+// memoryMock is used to test other components, especially when checking correct
+// error handling.
+type memoryMock struct {
+	mock.Mock
+}
+
+func (m *memoryMock) Set(key, value string) error {
+	args := m.Called(key, value)
+	return args.Error(0)
+}
+
+func (m *memoryMock) Get(key string) (string, bool, error) {
+	args := m.Called(key)
+	return args.String(0), args.Bool(1), args.Error(2)
+}
+
+func (m *memoryMock) Delete(key string) (bool, error) {
+	args := m.Called(key)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *memoryMock) Memories() (mm map[string]string, err error) {
+	args := m.Called()
+	if x := args.Get(0); x != nil {
+		mm = x.(map[string]string)
+	}
+
+	return mm, args.Error(1)
+}
+
+func (m *memoryMock) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}

--- a/message.go
+++ b/message.go
@@ -9,10 +9,12 @@ import (
 // to the RespondFunc that was registered via Bot.Respond(…) or Bot.RespondRegex(…)
 // when the message matches the regular expression of the handler.
 type Message struct {
-	Context context.Context
-	Text    string
-	Channel string
-	Matches []string // contains all sub matches of the regular expression that matched the Text
+	Context  context.Context
+	Text     string
+	AuthorID string
+	Channel  string
+	Matches  []string    // contains all sub matches of the regular expression that matched the Text
+	Data     interface{} // corresponds to the ReceiveMessageEvent.Data field
 
 	adapter Adapter
 }

--- a/options.go
+++ b/options.go
@@ -50,7 +50,7 @@ func (c *Config) Logger(name string) *zap.Logger {
 
 // SetMemory can be used to change the Memory implementation of the bots Brain.
 func (c *Config) SetMemory(mem Memory) {
-	c.brain.memory = mem
+	c.brain.SetMemory(mem)
 }
 
 // SetAdapter can be used to change the Adapter implementation of the Bot.


### PR DESCRIPTION
- Add ReceiveMessageEvent.Data field to allow using the underlying message type of the adapters
- Add ReceiveMessageEvent.AuthorID field to identify the author of the message
- Add Message.Data field which contains a copy of the ReceiveMessageEvent.Data value
- Add Message.AuthorID field which contains a copy of the ReceiveMessageEvent.AuthorID value 
- Add Auth.Grant(…) and Auth.CheckPermission(…) functions to allow implementing user permissions
- Add Brain.Close() function to let the brain implement the Memory interface
- Add Brain.SetMemory(…) function to give more control over a joe.Brain