### PR TITLE
Add link to Rocket.Chat Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ open a pull request.
 - File Memory: https://github.com/go-joe/file-memory
 - HTTP Server: https://github.com/go-joe/http-server
 - Cron Jobs: https://github.com/go-joe/cron
+- Rocket.Chat Adapter: https://github.com/dwmunster/rocket-adapter
 
 ## Built With
 


### PR DESCRIPTION
I've written an [adapter](https://github.com/dwmunster/rocket-adapter) for use with Rocket.Chat based off of the Slack adapter.

I'd be happy to make changes if there are any issues you would like corrected.