### PR TITLE
Add link to Telegram adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ open a pull request.
 - HTTP Server: https://github.com/go-joe/http-server
 - Cron Jobs: https://github.com/go-joe/cron
 - Rocket.Chat Adapter: https://github.com/dwmunster/rocket-adapter
+- Telegram Adapter: https://github.com/robertgzr/joe-telegram-adapter
 
 ## Built With
 


### PR DESCRIPTION
I wrote an [adapter](https://github.com/robertgzr/joe-telegram-adapter) for Telegram over the weekend...

I also have a [memory implementation](https://github.com/robertgzr/joe-bolt-memory) using [bolt](https://godoc.org/go.etcd.io/bbolt)

Both still need a README with some documentation but I wanted to open these anyway in case anybody else is interested in this...