### PR TITLE
Add ability to retrieve users and user permission scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 Once we reach the v1.0 release, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Add `Auth.GetUsers()` and `Auth.GetUserPermissions(…)` functions to allow retrieving all users as well as users permissions.
+- Add `Auth.Users()` and `Auth.UserPermissions(…)` functions to allow retrieving all users as well as users permissions.
 
 ## [v0.8.0] - 2019-04-21
 - Make Auth.Grant(…) idempotent and do not unnecessarily add smaller scopes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 Once we reach the v1.0 release, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Nothing so far
+- Add `Auth.GetUsers()` and `Auth.GetUserPermissions(…)` functions to allow retrieving all users as well as users permissions.
 
 ## [v0.8.0] - 2019-04-21
 - Make Auth.Grant(…) idempotent and do not unnecessarily add smaller scopes

--- a/auth.go
+++ b/auth.go
@@ -11,8 +11,7 @@ const (
 	// ErrNotAllowed is returned if the user is not allowed access to a specific scope.
 	ErrNotAllowed = Error("not allowed")
 
-	// PermissionKeyPrefix is a constant prefix appended to a userID
-	PermissionKeyPrefix = "joe.permissions."
+	permissionKeyPrefix = "joe.permissions."
 )
 
 // Auth implements logic to add user authorization checks to your bot.
@@ -229,14 +228,14 @@ func (a *Auth) updatePermissions(key string, permissions []string) error {
 }
 
 func (a *Auth) permissionsKey(userID string) string {
-	return PermissionKeyPrefix + userID
+	return permissionKeyPrefix + userID
 }
 
 func (a *Auth) userFromKey(key string) (string, error) {
-	if !strings.HasPrefix(key, PermissionKeyPrefix) {
+	if !strings.HasPrefix(key, permissionKeyPrefix) {
 		return "", errors.New("could not parse userID from key")
 
 	}
-	userID := strings.Replace(key, PermissionKeyPrefix, "", 1)
+	userID := strings.Replace(key, permissionKeyPrefix, "", 1)
 	return userID, nil
 }

--- a/auth.go
+++ b/auth.go
@@ -89,15 +89,15 @@ func (a *Auth) Users() ([]string, error) {
 
 // UserPermissions returns the permission scopes for a specific user
 func (a *Auth) UserPermissions(userID string) ([]string, error) {
+	a.logger.Debug("Retrieving user permissions",
+		zap.String("user_id", userID),
+	)
+	
 	key := a.permissionsKey(userID)
 	permissions, err := a.loadPermissions(key)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-
-	a.logger.Debug("Retrieving user permissions",
-		zap.String("user_id", userID),
-	)
 
 	return permissions, nil
 }

--- a/auth.go
+++ b/auth.go
@@ -77,11 +77,10 @@ func (a *Auth) Users() ([]string, error) {
 
 	var userIDs []string
 	for _, key := range keys {
-		userID, err := a.userFromKey(key)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse userID from key")
+		if strings.HasPrefix(key, permissionKeyPrefix) {
+			userID := strings.TrimPrefix(key, permissionKeyPrefix)
+			userIDs = append(userIDs, userID)
 		}
-		userIDs = append(userIDs, userID)
 	}
 
 	return userIDs, nil
@@ -92,7 +91,7 @@ func (a *Auth) UserPermissions(userID string) ([]string, error) {
 	a.logger.Debug("Retrieving user permissions",
 		zap.String("user_id", userID),
 	)
-	
+
 	key := a.permissionsKey(userID)
 	permissions, err := a.loadPermissions(key)
 	if err != nil {
@@ -229,13 +228,4 @@ func (a *Auth) updatePermissions(key string, permissions []string) error {
 
 func (a *Auth) permissionsKey(userID string) string {
 	return permissionKeyPrefix + userID
-}
-
-func (a *Auth) userFromKey(key string) (string, error) {
-	if !strings.HasPrefix(key, permissionKeyPrefix) {
-		return "", errors.New("could not parse userID from key")
-
-	}
-	userID := strings.Replace(key, permissionKeyPrefix, "", 1)
-	return userID, nil
 }

--- a/auth.go
+++ b/auth.go
@@ -66,8 +66,8 @@ func (a *Auth) CheckPermission(scope, userID string) error {
 	return ErrNotAllowed
 }
 
-// GetUsers returns a list of userIDs having one or more permission scopes
-func (a *Auth) GetUsers() ([]string, error) {
+// Users returns a list of userIDs having one or more permission scopes
+func (a *Auth) Users() ([]string, error) {
 	keys, err := a.store.Keys()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load permissions")
@@ -87,8 +87,8 @@ func (a *Auth) GetUsers() ([]string, error) {
 	return userIDs, nil
 }
 
-// GetUserPermissions returns the permission scopes for a specific user
-func (a *Auth) GetUserPermissions(userID string) ([]string, error) {
+// UserPermissions returns the permission scopes for a specific user
+func (a *Auth) UserPermissions(userID string) ([]string, error) {
 	key := a.permissionsKey(userID)
 	permissions, err := a.loadPermissions(key)
 	if err != nil {

--- a/auth.go
+++ b/auth.go
@@ -68,12 +68,12 @@ func (a *Auth) CheckPermission(scope, userID string) error {
 
 // Users returns a list of userIDs having one or more permission scopes
 func (a *Auth) Users() ([]string, error) {
+	a.logger.Debug("Retrieving all userIDs")
+
 	keys, err := a.store.Keys()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load permissions")
 	}
-
-	a.logger.Debug("Retrieving all userIDs")
 
 	var userIDs []string
 	for _, key := range keys {

--- a/auth.go
+++ b/auth.go
@@ -7,8 +7,13 @@ import (
 	"go.uber.org/zap"
 )
 
-// ErrNotAllowed is returned if the user is not allowed access to a specific scope.
-const ErrNotAllowed = Error("not allowed")
+const (
+	// ErrNotAllowed is returned if the user is not allowed access to a specific scope.
+	ErrNotAllowed = Error("not allowed")
+
+	// PermissionKeyPrefix is a constant prefix appended to a userID
+	PermissionKeyPrefix = "joe.permissions."
+)
 
 // Auth implements logic to add user authorization checks to your bot.
 type Auth struct {
@@ -60,6 +65,42 @@ func (a *Auth) CheckPermission(scope, userID string) error {
 	}
 
 	return ErrNotAllowed
+}
+
+// GetUsers returns a list of userIDs having one or more permission scopes
+func (a *Auth) GetUsers() ([]string, error) {
+	keys, err := a.store.Keys()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load permissions")
+	}
+
+	a.logger.Debug("Retrieving all userIDs")
+
+	var userIDs []string
+	for _, key := range keys {
+		userID, err := a.userFromKey(key)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse userID from key")
+		}
+		userIDs = append(userIDs, userID)
+	}
+
+	return userIDs, nil
+}
+
+// GetUserPermissions returns the permission scopes for a specific user
+func (a *Auth) GetUserPermissions(userID string) ([]string, error) {
+	key := a.permissionsKey(userID)
+	permissions, err := a.loadPermissions(key)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	a.logger.Debug("Retrieving user permissions",
+		zap.String("user_id", userID),
+	)
+
+	return permissions, nil
 }
 
 func (a *Auth) loadPermissions(key string) ([]string, error) {
@@ -188,5 +229,14 @@ func (a *Auth) updatePermissions(key string, permissions []string) error {
 }
 
 func (a *Auth) permissionsKey(userID string) string {
-	return "joe.permissions." + userID
+	return PermissionKeyPrefix + userID
+}
+
+func (a *Auth) userFromKey(key string) (string, error) {
+	if !strings.HasPrefix(key, PermissionKeyPrefix) {
+		return "", errors.New("could not parse userID from key")
+
+	}
+	userID := strings.Replace(key, PermissionKeyPrefix, "", 1)
+	return userID, nil
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -253,8 +253,8 @@ func TestAuth_GetUsers(t *testing.T) {
 	auth := joe.NewAuth(logger, store.Storage)
 
 	mustHaveUsers := map[string][]string{
-		"dave": []string{"bot.scopeA", "bot.scopeB"},
-		"john": []string{"bot.scopeC", "bot.scopeD"},
+		"dave": {"bot.scopeA", "bot.scopeB"},
+		"john": {"bot.scopeC", "bot.scopeD"},
 	}
 	for user, perms := range mustHaveUsers {
 		for _, scope := range perms {
@@ -265,7 +265,7 @@ func TestAuth_GetUsers(t *testing.T) {
 	// GetUsers() should return a list of userIDs
 	users, err := auth.GetUsers()
 	require.NoError(t, err)
-	for user, _ := range mustHaveUsers {
+	for user := range mustHaveUsers {
 		require.Contains(t, users, user)
 	}
 }
@@ -276,8 +276,8 @@ func TestAuth_GetUserPermissions(t *testing.T) {
 	auth := joe.NewAuth(logger, store.Storage)
 
 	mustHavePermissions := map[string][]string{
-		"dave": []string{"bot.scopeA", "bot.scopeB"},
-		"john": []string{"bot.scopeC", "bot.scopeD"},
+		"dave": {"bot.scopeA", "bot.scopeB"},
+		"john": {"bot.scopeC", "bot.scopeD"},
 	}
 	for user, perms := range mustHavePermissions {
 		for _, scope := range perms {

--- a/auth_test.go
+++ b/auth_test.go
@@ -247,7 +247,7 @@ func TestAuth_Revoke_Errors(t *testing.T) {
 	assert.EqualError(t, err, "failed to delete last user permission: not today")
 }
 
-func TestAuth_GetUsers(t *testing.T) {
+func TestAuth_Users(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	store := joetest.NewStorage(t)
 	auth := joe.NewAuth(logger, store.Storage)
@@ -262,15 +262,20 @@ func TestAuth_GetUsers(t *testing.T) {
 		}
 	}
 
-	// GetUsers() should return a list of userIDs
+	// set a non-permission key
+	store.Set("non.permission.key", "not-a-user")
+
+	// Users() should return a list of userIDs
 	users, err := auth.Users()
 	require.NoError(t, err)
+
+	require.Len(t, users, len(mustHaveUsers))
 	for user := range mustHaveUsers {
 		require.Contains(t, users, user)
 	}
 }
 
-func TestAuth_GetUserPermissions(t *testing.T) {
+func TestAuth_UserPermissions(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	store := joetest.NewStorage(t)
 	auth := joe.NewAuth(logger, store.Storage)
@@ -285,7 +290,7 @@ func TestAuth_GetUserPermissions(t *testing.T) {
 		}
 	}
 
-	// GetUserPermissions() should return all permission scopes for a user
+	// UserPermissions() should return all permission scopes for a user
 	for _, user := range []string{"dave", "john"} {
 		permissions, err := auth.UserPermissions(user)
 		require.NoError(t, err)
@@ -294,7 +299,6 @@ func TestAuth_GetUserPermissions(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}
-
 }
 
 type memoryMock struct {

--- a/auth_test.go
+++ b/auth_test.go
@@ -263,7 +263,7 @@ func TestAuth_GetUsers(t *testing.T) {
 	}
 
 	// GetUsers() should return a list of userIDs
-	users, err := auth.GetUsers()
+	users, err := auth.Users()
 	require.NoError(t, err)
 	for user := range mustHaveUsers {
 		require.Contains(t, users, user)
@@ -287,7 +287,7 @@ func TestAuth_GetUserPermissions(t *testing.T) {
 
 	// GetUserPermissions() should return all permission scopes for a user
 	for _, user := range []string{"dave", "john"} {
-		permissions, err := auth.GetUserPermissions(user)
+		permissions, err := auth.UserPermissions(user)
 		require.NoError(t, err)
 		for _, scope := range permissions {
 			err = auth.CheckPermission(scope, user)


### PR DESCRIPTION
I had a need to allow bot admins to list and view user permissions.

This PR adds the following functionnality:
- Retrieve bot users
- Retrieve permission scopes for a specific user

As I'm fairly new to go, please let me know if you see any mistakes or things that should be improved in this PR