### PR TITLE
Fix deadlock in joetest when registering invalid handlers

### DIFF
--- a/brain.go
+++ b/brain.go
@@ -135,6 +135,11 @@ func (b *Brain) isClosed() bool {
 //
 // If multiple handlers are registered for the same event type, then they are
 // all executed in the order in which they have been registered.
+//
+// You should register all handlers before you start the bot via Bot.Run(…).
+// While registering handlers later is also possible, any registration errors
+// will silently be ignored if you register an invalid handler when the bot is
+// already running.
 func (b *Brain) RegisterHandler(fun interface{}) {
 	err := b.registerHandler(fun)
 	if err != nil {

--- a/joetest/bot.go
+++ b/joetest/bot.go
@@ -101,7 +101,10 @@ func (b *Bot) Start() {
 
 	go func() {
 		// The error will be available by calling Bot.Stop()
-		_ = b.Run()
+		err := b.Run()
+		if err != nil {
+			close(started)
+		}
 	}()
 
 	<-started

--- a/joetest/bot_test.go
+++ b/joetest/bot_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-joe/joe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,6 +64,26 @@ func TestBot_RegistrationErrors(t *testing.T) {
 	case err := <-b.runErr:
 		require.Error(t, err)
 		assert.True(t, strings.HasPrefix(err.Error(), "invalid event handlers: "))
+		t.Log(err.Error())
+	case <-time.After(b.Timeout):
+		b.T.Errorf("Timeout")
+	}
+}
+
+func TestBot_RegistrationErrors2(t *testing.T) {
+	b := NewBot(t)
+
+	b.RespondRegex("invalid regex: (", func(joe.Message) error {
+		return joe.ErrNotImplemented
+	})
+
+	b.Start()
+
+	select {
+	case err := <-b.runErr:
+		require.Error(t, err)
+		assert.True(t, strings.HasPrefix(err.Error(), "invalid event handlers: "))
+		t.Log(err.Error())
 	case <-time.After(b.Timeout):
 		b.T.Errorf("Timeout")
 	}


### PR DESCRIPTION
Fixes #13