### PR TITLE
Correct which adapters support reactions

### DIFF
--- a/_docs/content/basics/06_reactions.md
+++ b/_docs/content/basics/06_reactions.md
@@ -14,7 +14,7 @@ Currently the following chat adapters support reactions:
 
 - <i class="fas fa-terminal"></i> CLI Adapter: https://github.com/go-joe/joe
 - <i class='fab fa-slack fa-fw'></i> Slack Adapter: https://github.com/go-joe/slack-adapter
-- <i class='fab fa-rocketchat fa-fw'></i> Rocket.Chat Adapter: https://github.com/dwmunster/rocket-adapter
+- <i class='fas fa-circle-notch'></i> Mattermost Adapter: https://github.com/dwmunster/joe-mattermost-adapter
 
 The following example shows how you can use reactions in your message handlers:
 


### PR DESCRIPTION
Currently, the Rocket.Chat adapter does not have a released version with Reactions support. I have some initial code on my master branch, but there are some bugs yet to be resolved.

On the other hand, the Mattermost adapter _does_ support Reactions (at least adding them to messages, still working on the event support).